### PR TITLE
test: switch to node build-in test runner and assert library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16, 18]
+        node-version: [20]
         os: [ubuntu-latest]
     steps:
       - name: Checkout repo

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Node.js API server/backend based on [fastify][fastify-site-url] and [MongoDB][mo
 * load .env to environment and validate using [fastify-env][fastify-env-url] and [dotenv][dotenv-url]
 * linting and fixing using [standard][standard-url]
 * git pre-commit hooks using [husky][husky-url]
-* integration tests with [node-tap][node-tap-url]
+* integration tests with [node test runner][node-test-url]
 * coverage report by [c8][c8-url] that leverages native v8 coverage report
 * continuous integration using [GitHub Actions CI][github-actions-url]
   * code coverage tracking using [coveralls][coveralls-url]
@@ -51,7 +51,7 @@ Linting is done using [standard][standard-url]. Use `npm run lint` to run linter
 
 ### Integration tests
 
-Integration tests are stored in test/**.spec.js. Tests are run by [node-tap][node-tap-url]. Run `npm run test` to run both unit and integration tests.
+Integration tests are stored in test/**.spec.js. Tests are run by [Node test runner][node-test-url]. Run `npm run test` to run both unit and integration tests.
 
 #### Coverage reports
 
@@ -76,7 +76,7 @@ Run `npm run coverage` to generate HTML test coverage report. Web browser is ope
 [github-actions-url]: https://github.com/features/actions
 [husky-url]: https://typicode.github.io/husky
 [mongodb-uri]: https://www.mongodb.com/
-[node-tap-url]: https://node-tap.org/
+[node-test-url]: https://nodejs.org/api/test.html
 [node-url]: https://nodejs.org/en/
 [npm-url]: https://www.npmjs.com/
 [release-drafter-url]: https://github.com/marketplace/actions/release-drafter

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "debug": "fastify start --debug --log-level info --log-level info --pretty-logs --watch src/app.js",
     "lint": "standard --verbose | snazzy && echo 'JavaScript Standard Style lint complete.'",
     "lint:fix": "standard --verbose --fix | snazzy && echo 'JavaScript Standard Style fix complete.'",
-    "unit": "c8 --check-coverage --lines 100 tap --no-coverage test/*.test.js",
+    "unit": "c8 --check-coverage --lines 100 node --test test",
     "coverage": "c8 report --reporter=html && npx http-server -o coverage/",
     "coverage:ci": "c8 report --reporter=text --reporter=lcovonly",
     "test": "npm run lint && npm run unit",
@@ -40,8 +40,7 @@
     "c8": "^7.13.0",
     "husky": "^8.0.3",
     "snazzy": "^9.0.0",
-    "standard": "*",
-    "tap": "^16.3.4"
+    "standard": "*"
   },
   "dependencies": {
     "fastify": "^4.15.0",

--- a/test/headers.test.js
+++ b/test/headers.test.js
@@ -1,77 +1,79 @@
-import { test } from 'tap'
+import { test, beforeEach, afterEach } from 'node:test'
+import { strict as assert } from 'node:assert'
 import { buildFastify, getLastLogItem } from './helper.js'
 
 const lastLogItem = getLastLogItem('headers')
 
 /* jscpd:ignore-start */
+beforeEach(async (t) => {
+  t.app = await buildFastify()
+})
+
+afterEach(async (t) => {
+  t.app.close()
+})
+
 test('GET `/api/headers` route', async t => {
-  const app = await buildFastify(t)
   const expectedHeaders = {
     'user-agent': 'lightMyRequest',
     host: 'localhost:80'
   }
 
-  const res = await app.inject({
+  const res = await t.app.inject({
     method: 'GET',
     url: '/api/headers'
   })
 
-  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.equal(res.statusCode, 200)
-  t.same(res.json(), expectedHeaders)
-  t.same(await lastLogItem(app.mongo.db), expectedHeaders)
+  assert.equal(res.headers['content-type'], 'application/json; charset=utf-8')
+  assert.equal(res.statusCode, 200)
+  assert.deepEqual(res.json(), expectedHeaders)
+  assert.deepEqual(await lastLogItem(t.app.mongo.db), expectedHeaders)
 })
 
 test('GET `/api/headers` route additional headers', async t => {
-  const app = await buildFastify(t)
-
   const expectedHeaders = {
-    'x-my-header': 42,
+    'x-my-header': '42',
     'user-agent': 'lightMyRequest',
     host: 'localhost:80'
   }
 
-  const res = await app.inject({
+  const res = await t.app.inject({
     method: 'GET',
     url: '/api/headers',
-    headers: { 'x-my-header': 42 }
+    headers: { 'x-my-header': '42' }
   })
 
-  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.equal(res.statusCode, 200)
-  t.same(res.json(), expectedHeaders)
-  t.same(await lastLogItem(app.mongo.db), expectedHeaders)
+  assert.equal(res.headers['content-type'], 'application/json; charset=utf-8')
+  assert.equal(res.statusCode, 200)
+  assert.deepEqual(res.json(), expectedHeaders)
+  assert.deepEqual(await lastLogItem(t.app.mongo.db), expectedHeaders)
 })
 
 test('GET `/api/headers?delay=1` route', async t => {
-  const app = await buildFastify(t)
-
   const expectedHeaders = {
     'user-agent': 'lightMyRequest',
     host: 'localhost:80'
   }
 
-  const res = await app.inject({
+  const res = await t.app.inject({
     method: 'GET',
     url: '/api/headers'
   })
 
-  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.equal(res.statusCode, 200)
-  t.same(res.json(), expectedHeaders)
-  t.same(await lastLogItem(app.mongo.db), expectedHeaders)
+  assert.equal(res.headers['content-type'], 'application/json; charset=utf-8')
+  assert.equal(res.statusCode, 200)
+  assert.deepEqual(res.json(), expectedHeaders)
+  assert.deepEqual(await lastLogItem(t.app.mongo.db), expectedHeaders)
 })
 
 test('GET `/api/headers?delay=A` route', async t => {
-  const app = await buildFastify(t)
-
-  const res = await app.inject({
+  const res = await t.app.inject({
     method: 'GET',
     url: '/api/headers?delay=A'
   })
 
-  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.equal(res.statusCode, 400)
-  t.equal(res.statusMessage, 'Bad Request')
+  assert.equal(res.headers['content-type'], 'application/json; charset=utf-8')
+  assert.equal(res.statusCode, 400)
+  assert.equal(res.statusMessage, 'Bad Request')
 })
 /* jscpd:ignore-end */

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,11 +1,10 @@
 import Fastify from 'fastify'
 import app from '../src/app.js'
 
-export async function buildFastify (t, opts = {}) {
+export async function buildFastify (opts = {}) {
   const fastify = await app(Fastify(), opts)
   await fastify.ready()
 
-  t.teardown(fastify.close.bind(fastify))
   return fastify
 }
 

--- a/test/ping.test.js
+++ b/test/ping.test.js
@@ -1,78 +1,81 @@
-import { test } from 'tap'
+import { test, beforeEach, afterEach } from 'node:test'
+import { strict as assert } from 'node:assert'
 import { buildFastify, getLastLogItem } from './helper.js'
 
 const lastLogItem = getLastLogItem('ping')
 
 /* jscpd:ignore-start */
+beforeEach(async (t) => {
+  t.app = await buildFastify()
+})
+
+afterEach(async (t) => {
+  t.app.close()
+})
+
 test('GET `/api/ping` route', async t => {
-  const app = await buildFastify(t)
   const expectedResult = { ping: 'pong' }
 
-  const res = await app.inject({
+  const res = await t.app.inject({
     method: 'GET',
     url: '/api/ping'
   })
 
-  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.equal(res.statusCode, 200)
-  t.same(res.json(), expectedResult)
-  t.same(await lastLogItem(app.mongo.db), expectedResult)
+  assert.equal(res.headers['content-type'], 'application/json; charset=utf-8')
+  assert.equal(res.statusCode, 200)
+  assert.deepEqual(res.json(), expectedResult)
+  assert.deepEqual(await lastLogItem(t.app.mongo.db), expectedResult)
 })
 
 test('GET `/api/ping?delay=1` route', async t => {
-  const app = await buildFastify(t)
   const expectedResult = { ping: 'pong' }
 
-  const res = await app.inject({
+  const res = await t.app.inject({
     method: 'GET',
     url: '/api/ping?delay=1'
   })
 
-  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.equal(res.statusCode, 200)
-  t.same(res.json(), expectedResult)
-  t.same(await lastLogItem(app.mongo.db), expectedResult)
+  assert.equal(res.headers['content-type'], 'application/json; charset=utf-8')
+  assert.equal(res.statusCode, 200)
+  assert.deepEqual(res.json(), expectedResult)
+  assert.deepEqual(await lastLogItem(t.app.mongo.db), expectedResult)
 })
 
 test('GET `/api/ping?delay=A` route', async t => {
-  const app = await buildFastify(t)
-
-  const res = await app.inject({
+  const res = await t.app.inject({
     method: 'GET',
     url: '/api/ping?delay=A'
   })
 
-  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.equal(res.statusCode, 400)
-  t.equal(res.statusMessage, 'Bad Request')
+  assert.equal(res.headers['content-type'], 'application/json; charset=utf-8')
+  assert.equal(res.statusCode, 400)
+  assert.equal(res.statusMessage, 'Bad Request')
 })
 
 test('GET `/api/ping/bang` route', async t => {
-  const app = await buildFastify(t)
   const expectedResult = { ping: 'bang' }
 
-  const res = await app.inject({
+  const res = await t.app.inject({
     method: 'GET',
     url: '/api/ping/bang'
   })
 
-  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.equal(res.statusCode, 200)
-  t.same(res.json(), expectedResult)
-  t.same(await lastLogItem(app.mongo.db), expectedResult)
+  assert.equal(res.headers['content-type'], 'application/json; charset=utf-8')
+  assert.equal(res.statusCode, 200)
+  assert.deepEqual(res.json(), expectedResult)
+  assert.deepEqual(await lastLogItem(t.app.mongo.db), expectedResult)
 })
 
 test('GET `/api/ping/bang?delay=1` route', async t => {
-  const app = await buildFastify(t)
   const expectedResult = { ping: 'bang' }
-  const res = await app.inject({
+  const res = await t.app.inject({
     method: 'GET',
     url: '/api/ping/bang?delay=1'
   })
 
-  t.equal(res.headers['content-type'], 'application/json; charset=utf-8')
-  t.equal(res.statusCode, 200)
-  t.same(res.json(), expectedResult)
-  t.same(await lastLogItem(app.mongo.db), expectedResult)
+  assert.equal(res.headers['content-type'], 'application/json; charset=utf-8')
+  assert.equal(res.statusCode, 200)
+  assert.deepEqual(res.json(), expectedResult)
+  assert.deepEqual(await lastLogItem(t.app.mongo.db), expectedResult)
 })
 /* jscpd:ignore-end */


### PR DESCRIPTION
Switch from node-tap to node build-in test runner and assertion library. 
Keep c8 for code coverage.