### PR TITLE
Fix test path for delay query param

### DIFF
--- a/test/headers.test.js
+++ b/test/headers.test.js
@@ -58,7 +58,7 @@ test('GET `/api/headers?delay=1` route', async t => {
 
   const res = await t.app.inject({
     method: 'GET',
-    url: '/api/headers'
+    url: '/api/headers?delay=1'
   })
 
   assert.equal(res.headers['content-type'], 'application/json; charset=utf-8')


### PR DESCRIPTION
## Summary
- fix the URL in `GET `/api/headers?delay=1` route` test to include the query parameter

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683d86216f048331a249d312e90762b3