### PR TITLE
Fix env var validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ These instructions will get you a copy of the project up and running on your loc
 
 Use .env to store your environment-dependent configuration options and secrets; this file should not be checked into your repository. Use .env.example as an example but exclude real secrets.
 
+The server accepts two environment variables:
+
+* `FASTIFY_PORT` &ndash; listening port. It defaults to `3000` and must be an integer.
+* `MONGODB_URI` &ndash; MongoDB connection string. This variable is required and must not be empty.
+
 ### Linting and code fixing
 
 Linting is done using [neostandard][neostandard-url]. Use `npm run lint` to run linter. You can also automatically fix linter errors by running `npm run lint:fix`.

--- a/src/config.js
+++ b/src/config.js
@@ -5,12 +5,12 @@ export const config = {
     required: ['MONGODB_URI'],
     properties: {
       FASTIFY_PORT: {
-        type: 'string',
+        type: 'integer',
         default: 3000
       },
       MONGODB_URI: {
         type: 'string',
-        default: ''
+        minLength: 1
       }
     }
   }

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,6 +1,10 @@
 import Fastify from 'fastify'
 import app from '../src/app.js'
 
+if (!process.env.MONGODB_URI) {
+  process.env.MONGODB_URI = 'mongodb://localhost:27017/test-db'
+}
+
 export async function buildFastify (opts = {}) {
   const fastify = await app(Fastify(), opts)
   await fastify.ready()


### PR DESCRIPTION
## Summary
- enforce required `MONGODB_URI` and integer `FASTIFY_PORT`
- document environment variables
- provide default `MONGODB_URI` for tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683d8b75a4648331b95c176524e66072