### PR TITLE
Add logging error handling

### DIFF
--- a/src/utils/__test__/utils.test.js
+++ b/src/utils/__test__/utils.test.js
@@ -1,0 +1,32 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { createLogger } from '../utils.js'
+
+// ensure logger doesn't throw when insertOne fails
+
+/** @type {Error[]} */
+const loggedErrors = []
+
+function mockConsoleError (...args) {
+  loggedErrors.push(args)
+}
+
+test('createLogger handles insert errors', async () => {
+  const logger = createLogger('test-service')
+  const document = { foo: 'bar' }
+  const mockCollection = {
+    async insertOne () {
+      throw new Error('db down')
+    }
+  }
+
+  const original = console.error
+  console.error = mockConsoleError
+  const result = await logger(document, mockCollection)
+  console.error = original
+
+  assert.equal(result.foo, 'bar')
+  assert.equal(result.service, 'test-service')
+  assert.ok(result.createdAt instanceof Date)
+  assert.equal(loggedErrors.length, 1)
+})

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -3,6 +3,10 @@ export { setTimeout as sleep } from 'node:timers/promises'
 export const createLogger = service =>
   async (document, collection) => {
     const result = { service, ...document, createdAt: new Date() }
-    await collection.insertOne(result, { w: 1 })
+    try {
+      await collection.insertOne(result, { w: 1 })
+    } catch (err) {
+      console.error(`Unable to write log for ${service}`, err)
+    }
     return result
   }


### PR DESCRIPTION
## Summary
- handle database errors in `createLogger`
- add unit test covering failed insert scenario

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_683d8c2ddd088331baef43c57589f784