### PR TITLE
Fix duplicated flag in debug script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "start": "fastify start --log-level info --pretty-logs --watch src/app.js",
-    "debug": "fastify start --debug --log-level info --log-level info --pretty-logs --watch src/app.js",
+    "debug": "fastify start --debug --log-level info --pretty-logs --watch src/app.js",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "test:unit": "node --test src/**/__test__/**/*.test.js",


### PR DESCRIPTION
## Summary
- remove redundant `--log-level` flag from the debug script in `package.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683d96cd39f88331bdddcafe3a50c778