### PR TITLE
Tighten schemas for ping and headers

### DIFF
--- a/src/services/headers/schema.js
+++ b/src/services/headers/schema.js
@@ -3,14 +3,15 @@ export const headersSchema = {
     type: 'object',
     properties: {
       delay: { type: 'integer' }
-    }
+    },
+    additionalProperties: false
   },
   response: {
     200: {
       type: 'object',
       properties: {
       },
-      additionalProperties: true
+      additionalProperties: { type: 'string' }
     }
   }
 }

--- a/src/services/ping/schema.js
+++ b/src/services/ping/schema.js
@@ -3,14 +3,17 @@ export const pingSchema = {
     type: 'object',
     properties: {
       delay: { type: 'integer' }
-    }
+    },
+    additionalProperties: false
   },
   response: {
     200: {
       type: 'object',
       properties: {
         ping: { type: 'string' }
-      }
+      },
+      required: ['ping'],
+      additionalProperties: false
     }
   }
 }


### PR DESCRIPTION
## Summary
- validate query parameters strictly for ping and headers
- mark ping response as requiring its `ping` field
- restrict headers response values to strings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683d96dc8f08833199543aed9031b21e